### PR TITLE
fix zoom in to get cell state plot from dotplot

### DIFF
--- a/src/utils/chatSideEffects.js
+++ b/src/utils/chatSideEffects.js
@@ -144,11 +144,11 @@ export const updateChat = async (response, plotState) => {
       params = {
         organ: plotState.organ,
         organism: plotState.organism,
-        features: plotState.features.join(","),
+        features: plotState.features,
         // FIXME: see above
         measurement_type: "gene_expression",
       };
-  }
+    }
 
     if (mainIntent === 'fraction_detected') {
       endpoint = "dotplot";
@@ -184,7 +184,6 @@ export const updateChat = async (response, plotState) => {
 
     //  Finally, generate bot response and api data for the given intent
     apiData = await atlasapprox[endpoint](params);
-  
     if (intent === "organisms.geneExpression") {
       let numOrganisms = apiData.organisms.length;
       answer = `There are ${numOrganisms} organisms available:<br>`;

--- a/src/utils/updatePlotState.js
+++ b/src/utils/updatePlotState.js
@@ -147,7 +147,7 @@ const updateNeighbor = (context) => {
         plotType: "neighborhood",
         organism: context.organism,
         organ: context.organ,
-        features: context.features.split(","),
+        features: Array.isArray(context.features) ? context.features : context.features.split(","),
         celltypes: context.response.data.celltypes,
         nCells: transpose(context.response.data.ncells),
         boundaries: context.response.data.boundaries,


### PR DESCRIPTION
Before: 
If we start from a cell state plot and then zoom out/zoom in, it works well.
But if we start from a dotplot "Show a dotplot of ML25764a, ML358828a, ML071151a, ML065728a in jellyfish whole." and then zoom in and zoom out, it does not work.

Bug fixed.