### PR TITLE
Update bot's response for cases when no markers are detected

### DIFF
--- a/src/utils/chatSideEffects.js
+++ b/src/utils/chatSideEffects.js
@@ -110,7 +110,7 @@ export const updateChat = async (response, plotState) => {
     }
 
     // for intents that without actual data, we need to make extra api calls
-    if (mainIntent === 'markers' || mainIntent === 'similar_features') {
+    if (mainIntent === 'similar_features') {
       extraEndpointsToCall.push('dotplot');
     } 
 
@@ -206,6 +206,13 @@ export const updateChat = async (response, plotState) => {
     }
 
 
+    if (intent === "markers.geneExpression") {
+      if (apiData.markers.length === 0) {
+        answer = `There is no markers detected in ${apiData.organism} ${apiData.organ}`;
+      } else {
+          extraEndpointsToCall.push('dotplot');
+      }
+    }
     // for intent like "marker, fraction, similar celltypes"
     for (const e of extraEndpointsToCall) {
       if (mainIntent === 'similar_features' || mainIntent === 'markers') {

--- a/src/utils/updatePlotState.js
+++ b/src/utils/updatePlotState.js
@@ -50,6 +50,9 @@ const toggleLog = (context) => {
 };
 
 const updateMarkers = (context) => {
+    if(context.markers.length === 0) {
+        return;
+    }
     let features = context.markers.join(",");
     return updateFractions({ ...context, features });
 


### PR DESCRIPTION
Hi Fabio,

When no markers are found for a query, it will update the response message without generating the dot plot.

This PR is ready for merging