### PR TITLE
Updated axis hover text for switching between acorss organ and cell type plots

### DIFF
--- a/src/components/plots/BubbleHeatmap.js
+++ b/src/components/plots/BubbleHeatmap.js
@@ -9,7 +9,6 @@ const BubbleHeatmap = ({ state, hoveredGene, setHoveredGeneColor, setHoveredGene
 
   let { plotType, xaxis, yaxis, average, fractions, organism, organ, celltype, unit, hasLog, measurement_type } = state;
   let yTickTexts;
-  console.log(plotType);
   if (organism === 'h_sapiens' && measurement_type === 'gene_expression') {
     let geneCardLink = (gene) => `https://www.genecards.org/cgi-bin/carddisp.pl?gene=${gene}`;
     yTickTexts = yaxis.map((gene) => {

--- a/src/components/plots/BubbleHeatmap.js
+++ b/src/components/plots/BubbleHeatmap.js
@@ -9,6 +9,7 @@ const BubbleHeatmap = ({ state, hoveredGene, setHoveredGeneColor, setHoveredGene
 
   let { plotType, xaxis, yaxis, average, fractions, organism, organ, celltype, unit, hasLog, measurement_type } = state;
   let yTickTexts;
+  console.log(plotType);
   if (organism === 'h_sapiens' && measurement_type === 'gene_expression') {
     let geneCardLink = (gene) => `https://www.genecards.org/cgi-bin/carddisp.pl?gene=${gene}`;
     yTickTexts = yaxis.map((gene) => {

--- a/src/utils/updatePlotState.js
+++ b/src/utils/updatePlotState.js
@@ -109,7 +109,6 @@ const updateAverage = (context) => {
 };
 
 const updateFractions = (context) => {
-    console.log(context);
     let xAxis, plotType, average, fractions, unit, yAxis, measurement_type;
     if (context.intent.split('.')[2] === "across_organs" || (["add", "remove", "plot"].includes(context.intent.split('.')[0]) && context.plotState.plotType.endsWith("AcrossOrgans"))) {
         if (context.response.data) {

--- a/src/utils/updatePlotState.js
+++ b/src/utils/updatePlotState.js
@@ -1,3 +1,4 @@
+import { celltypes } from "@fabilab/atlasapprox";
 import transpose from "./math";
 
 const exploreOrganism = (context) => {
@@ -70,6 +71,7 @@ const updateAverage = (context) => {
         }
         plotType = "averageAcrossOrgans";
     } else {
+        context.celltype = false;
         if (context.response.data) {
           xAxis = context.response.data.celltypes;
           average = context.response.data.average;
@@ -107,6 +109,7 @@ const updateAverage = (context) => {
 };
 
 const updateFractions = (context) => {
+    console.log(context);
     let xAxis, plotType, average, fractions, unit, yAxis, measurement_type;
     if (context.intent.split('.')[2] === "across_organs" || (["add", "remove", "plot"].includes(context.intent.split('.')[0]) && context.plotState.plotType.endsWith("AcrossOrgans"))) {
         if (context.response.data) {
@@ -120,6 +123,7 @@ const updateFractions = (context) => {
         }
         plotType = "fractionDetectedAcrossOrgans";
     } else {
+        context.celltype = false;
         if (context.response.data) {
           xAxis = context.response.data.celltypes;
           average = context.response.data.average;


### PR DESCRIPTION
Bug:
When users compared data across different organs and then switched to comparing across cell types, the hover label incorrectly remained as 'organ'. 
<img width="444" alt="Screen Shot 2023-12-12 at 10 27 48 am" src="https://github.com/fabilab/cell_atlas_approximations_HI/assets/98261770/6372d410-9aba-48d4-a23b-0eaec056bf8e">

This PR is ready for merging.
