### PR TITLE
zoom in from scatter plot to view data by cell states

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@fabilab/atlasapprox": "^0.2.7",
-        "@fabilab/atlasapprox-nlp": "^0.2.30",
+        "@fabilab/atlasapprox-nlp": "^0.2.31",
         "@fortawesome/fontawesome-free": "^6.4.0",
         "@fortawesome/fontawesome-svg-core": "^6.4.0",
         "@fortawesome/free-solid-svg-icons": "^6.4.0",
@@ -2716,9 +2716,9 @@
       "integrity": "sha512-w+UwZkBwak1VIY32U6ysy6MyV4heVVdBIw0qerwYL6/w1bNC6gyXGykj9RLK3Ep0Nz/ZMhEztDRnlcG9601H2A=="
     },
     "node_modules/@fabilab/atlasapprox-nlp": {
-      "version": "0.2.31",
-      "resolved": "https://registry.npmjs.org/@fabilab/atlasapprox-nlp/-/atlasapprox-nlp-0.2.31.tgz",
-      "integrity": "sha512-gR+8PvuV52c0smDf38N2FTe49/gvdrOdXg0s8kRSpOoRJo1cPu9GXTtMyu7AdOsw/LgYjLi+YLlvdXRqv37Mig==",
+      "version": "0.2.33",
+      "resolved": "https://registry.npmjs.org/@fabilab/atlasapprox-nlp/-/atlasapprox-nlp-0.2.33.tgz",
+      "integrity": "sha512-+LvEFG7Gr06uhBBN8wBpT7+jfcocYRM2Q5BM4fH1WyzTwZE4lYGD4CTOStx9vWbvoYfnaHvN+AR0ZQZLKjYAOA==",
       "dependencies": {
         "@nlpjs/basic": "^4.27.0",
         "@nlpjs/core": "^4.26.1",

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -31,7 +31,7 @@ const Landing = () => {
     'What cell type is the highest expressor of GZMA in human?',
     'List highest accessibility of chr1:9955-10355 in human.',
     'What are the sequences of COL1A1,CD19,ALK,VWF in human?',
-    "what cell types coexpress CD19 and COL1A1 in human?",
+    "what cell types coexpress PDGFRA and ADGRE1 in human?",
     'show the 15 top marker peaks for astrocyte in human brain',
     'What are 10 peaks similar to chr8:107381240-107381640 in human brain?',
     'What is the chromatin accessibility of chr1:9955-10355, chr10:122199710-122200110 in human lung?',

--- a/src/components/plots/CoexpressScatter.js
+++ b/src/components/plots/CoexpressScatter.js
@@ -6,7 +6,8 @@ import orgMeta from '../../utils/organismMetadata.js';
 
 const CoexpressScatter = ({ state }) => {
 
-    let { plotType, organism, featureX, featureY, expData, unit, hasLog } = state;
+    let { plotType, organism, featureX, featureY, expData, unit, hasLog, by } = state;
+
     let dataSource = orgMeta[organism]?.dataSource || "Data source not available";
     let paperHyperlink = orgMeta[organism]?.paperHyperlink || "Hyperlink unavailable";
 
@@ -32,22 +33,23 @@ const CoexpressScatter = ({ state }) => {
     const plotData = expData.map(item => ({
         x: item.average[0],
         y: item.average[1],
-        celltype: item.celltypes,
         mode: 'markers',
         type: 'scatter',
         name: item.organ,
-        text: item.celltypes.map((cellType, index) => 
-        `${featureX}: ${item.average[0][index]}<br>${featureY}: ${item.average[1][index]}<br>Organ: ${item.organ}<br>Cell type: ${cellType}`
-        ),
+        text: item.average[0].map((_, idx) => {
+            const baseText = `${featureX}: ${item.average[0][idx]}<br>${featureY}: ${item.average[1][idx]}<br>Organ: ${item.organ}`;
+            return by === "celltype" ? `${baseText}<br>Cell type: ${item.celltypes[idx]}` : `${baseText}<br>Cell state: ${idx + 1}`;
+        }),
         marker: { 
             size: 12,
             color: organColorMap[item.organ],
+            symbol: by === "celltype" ? 'circle' : 'square',
         },
         hoverinfo: 'text',
     }));
 
     var layout = {
-        title: `Co-expression of ${featureX} and ${featureY} across cell types and organs in ${organism}`,
+        title: `Co-expression of ${featureX} and ${featureY} across ${by} and organs in ${organism}`,
         xaxis: {
             title: featureX + ` (${unit})`,
             autorange: true,

--- a/src/utils/updatePlotState.js
+++ b/src/utils/updatePlotState.js
@@ -224,16 +224,20 @@ const updateNeighbor = (context) => {
 };
 
 const updateComeasurement = (context) => {
-    let expData, unit;
+    let expData, unit, organs, by;
     // by deault:
     if (context.response.data) {
         expData = context.response.data.expData
         unit = expData[0].unit
+        organs = context.response.data.organs
+        by = context.response.data.by
     }
     //  after appling log:
     else {
         expData = context.plotState.expData
         unit = context.plotState.unit;
+        organs = context.plotState.organs
+        by = context.plotState.by
     }
   
     const features = context.features.split(',');
@@ -247,6 +251,8 @@ const updateComeasurement = (context) => {
         expData: expData,
         unit: unit,
         hasLog: context.plotState.hasLog,
+        organs: organs,
+        by: by,
     };
 }
 
@@ -371,7 +377,6 @@ const plotFunctionDispatcher = {
 
 // Main "public" update plot state function
 export const updatePlotState = (response, plotState, setPlotState) => {
-
   const intent = response.intent;
   const mainIntent = intent.split('.')[0];
   let newPlotState = null;


### PR DESCRIPTION
Updates:

- Users can now switch the scatter plot from by cell type to cell states
- To do: implement zoom-out to switch back to cell type, code refactor (a little slow at the moment).
- 
<img width="742" alt="Screen Shot 2024-03-20 at 1 41 06 pm" src="https://github.com/fabilab/cell_atlas_approximations_HI/assets/98261770/71402250-696f-4b7d-b80c-079b3df2809d">
